### PR TITLE
Add support for pain.001.001.09 and pain.008.001.08

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    sepa_file_parser (0.2.1)
+    sepa_file_parser (0.2.2)
       bigdecimal
       nokogiri
       time

--- a/lib/sepa_file_parser/register.rb
+++ b/lib/sepa_file_parser/register.rb
@@ -18,6 +18,7 @@ SepaFileParser::Xml.register('urn:iso:std:iso:20022:tech:xsd:camt.054.001.04', :
 
 ## PAIN001
 SepaFileParser::Xml.register('urn:iso:std:iso:20022:tech:xsd:pain.001.001.03', :pain001)
+SepaFileParser::Xml.register('urn:iso:std:iso:20022:tech:xsd:pain.001.001.09', :pain001)
 
 ## PAIN002
 SepaFileParser::Xml.register('urn:iso:std:iso:20022:tech:xsd:pain.002.001.03', :pain002)
@@ -25,3 +26,4 @@ SepaFileParser::Xml.register('urn:iso:std:iso:20022:tech:xsd:pain.002.001.10', :
 
 ## PAIN008
 SepaFileParser::Xml.register('urn:iso:std:iso:20022:tech:xsd:pain.008.003.02', :pain008)
+SepaFileParser::Xml.register('urn:iso:std:iso:20022:tech:xsd:pain.008.001.08', :pain008)

--- a/lib/sepa_file_parser/version.rb
+++ b/lib/sepa_file_parser/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SepaFileParser
-  VERSION = '0.2.1'.freeze
+  VERSION = '0.2.2'.freeze
 end

--- a/spec/fixtures/pain001/valid_example_v9.xml
+++ b/spec/fixtures/pain001/valid_example_v9.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Document xmlns="urn:iso:std:iso:20022:tech:xsd:pain.001.001.09" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:iso:std:iso:20022:tech:xsd:pain.001.001.09 pain.001.001.09.xsd">
+  <CstmrCdtTrfInitn>
+    <GrpHdr>
+      <MsgId>SEPA-KING/9f2d8de0c8dc62a1345a87</MsgId>
+      <CreDtTm>2024-06-13T09:38:06+02:00</CreDtTm>
+      <NbOfTxs>1</NbOfTxs>
+      <CtrlSum>102.50</CtrlSum>
+      <InitgPty>
+        <Nm>Schuldner GmbH</Nm>
+      </InitgPty>
+    </GrpHdr>
+    <PmtInf>
+      <PmtInfId>SEPA-KING/9f2d8de0c8dc62a1345a87/1</PmtInfId>
+      <PmtMtd>TRF</PmtMtd>
+      <BtchBookg>true</BtchBookg>
+      <NbOfTxs>1</NbOfTxs>
+      <CtrlSum>102.50</CtrlSum>
+      <PmtTpInf>
+        <SvcLvl>
+          <Cd>SEPA</Cd>
+        </SvcLvl>
+      </PmtTpInf>
+      <ReqdExctnDt>
+        <Dt>2024-06-14</Dt>
+      </ReqdExctnDt>
+      <Dbtr>
+        <Nm>Schuldner GmbH</Nm>
+      </Dbtr>
+      <DbtrAcct>
+        <Id>
+          <IBAN>DE87200500001234567890</IBAN>
+        </Id>
+      </DbtrAcct>
+      <DbtrAgt>
+        <FinInstnId>
+          <BICFI>BANKDEFFXXX</BICFI>
+        </FinInstnId>
+      </DbtrAgt>
+      <ChrgBr>SLEV</ChrgBr>
+      <CdtTrfTxInf>
+        <PmtId>
+          <InstrId>12345</InstrId>
+          <EndToEndId>XYZ-1234/123</EndToEndId>
+        </PmtId>
+        <Amt>
+          <InstdAmt Ccy="EUR">102.50</InstdAmt>
+        </Amt>
+        <CdtrAgt>
+          <FinInstnId>
+            <BICFI>PBNKDEFF370</BICFI>
+          </FinInstnId>
+        </CdtrAgt>
+        <Cdtr>
+          <Nm>Telekomiker AG</Nm>
+        </Cdtr>
+        <CdtrAcct>
+          <Id>
+            <IBAN>DE37112589611964645802</IBAN>
+          </Id>
+        </CdtrAcct>
+        <RmtInf>
+          <Ustrd>Rechnung vom 22.08.2013</Ustrd>
+        </RmtInf>
+      </CdtTrfTxInf>
+    </PmtInf>
+  </CstmrCdtTrfInitn>
+</Document>

--- a/spec/fixtures/pain008/valid_example_v8.xml
+++ b/spec/fixtures/pain008/valid_example_v8.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Document xmlns="urn:iso:std:iso:20022:tech:xsd:pain.008.001.08" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:iso:std:iso:20022:tech:xsd:pain.008.001.08 pain.008.001.08.xsd">
+  <CstmrDrctDbtInitn>
+    <GrpHdr>
+      <MsgId>example/35d37060c3e8d6288b5377</MsgId>
+      <CreDtTm>2024-06-13T09:41:51+02:00</CreDtTm>
+      <NbOfTxs>1</NbOfTxs>
+      <CtrlSum>39.99</CtrlSum>
+      <InitgPty>
+        <Nm>Gläubiger GmbH</Nm>
+        <Id>
+          <OrgId>
+            <Othr>
+              <Id>DE98ZZZ09999999999</Id>
+            </Othr>
+          </OrgId>
+        </Id>
+      </InitgPty>
+    </GrpHdr>
+    <PmtInf>
+      <PmtInfId>example/35d37060c3e8d6288b5377/1</PmtInfId>
+      <PmtMtd>DD</PmtMtd>
+      <BtchBookg>true</BtchBookg>
+      <NbOfTxs>1</NbOfTxs>
+      <CtrlSum>39.99</CtrlSum>
+      <PmtTpInf>
+        <SvcLvl>
+          <Cd>SEPA</Cd>
+        </SvcLvl>
+        <LclInstrm>
+          <Cd>CORE</Cd>
+        </LclInstrm>
+        <SeqTp>FRST</SeqTp>
+      </PmtTpInf>
+      <ReqdColltnDt>2024-06-14</ReqdColltnDt>
+      <Cdtr>
+        <Nm>Gläubiger GmbH</Nm>
+      </Cdtr>
+      <CdtrAcct>
+        <Id>
+          <IBAN>DE87200500001234567890</IBAN>
+        </Id>
+      </CdtrAcct>
+      <CdtrAgt>
+        <FinInstnId>
+          <BICFI>BANKDEFFXXX</BICFI>
+        </FinInstnId>
+      </CdtrAgt>
+      <ChrgBr>SLEV</ChrgBr>
+      <CdtrSchmeId>
+        <Id>
+          <PrvtId>
+            <Othr>
+              <Id>DE98ZZZ09999999999</Id>
+              <SchmeNm>
+                <Prtry>SEPA</Prtry>
+              </SchmeNm>
+            </Othr>
+          </PrvtId>
+        </Id>
+      </CdtrSchmeId>
+      <DrctDbtTxInf>
+        <PmtId>
+          <InstrId>12345</InstrId>
+          <EndToEndId>XYZ/2013-08-ABO/6789</EndToEndId>
+        </PmtId>
+        <InstdAmt Ccy="EUR">39.99</InstdAmt>
+        <DrctDbtTx>
+          <MndtRltdInf>
+            <MndtId>K-02-2011-12345</MndtId>
+            <DtOfSgntr>2024-01-25</DtOfSgntr>
+          </MndtRltdInf>
+        </DrctDbtTx>
+        <DbtrAgt>
+          <FinInstnId>
+            <BICFI>SPUEDE2UXXX</BICFI>
+          </FinInstnId>
+        </DbtrAgt>
+        <Dbtr>
+          <Nm>Zahlemann &amp; Söhne GbR</Nm>
+        </Dbtr>
+        <DbtrAcct>
+          <Id>
+            <IBAN>DE21500500009876543210</IBAN>
+          </Id>
+        </DbtrAcct>
+        <RmtInf>
+          <Ustrd>Vielen Dank für Ihren Einkauf</Ustrd>
+        </RmtInf>
+      </DrctDbtTxInf>
+    </PmtInf>
+  </CstmrDrctDbtInitn>
+</Document>

--- a/spec/lib/sepa_file_parser/pain001/base_spec.rb
+++ b/spec/lib/sepa_file_parser/pain001/base_spec.rb
@@ -4,20 +4,40 @@ require 'spec_helper'
 
 RSpec.describe SepaFileParser::Pain001::Base do
 
-  context 'initialization' do
-    after do
-      SepaFileParser::File.parse 'spec/fixtures/pain001/valid_example.xml'
+  context 'version 3' do
+    context 'initialization' do
+      after do
+        SepaFileParser::File.parse 'spec/fixtures/pain001/valid_example.xml'
+      end
+
+      specify { expect(SepaFileParser::GroupHeader).to receive(:new).and_call_original }
+      specify do
+        expect(SepaFileParser::Pain001::PaymentInformation).to receive(:new).and_call_original
+      end
     end
 
-    specify { expect(SepaFileParser::GroupHeader).to receive(:new).and_call_original }
-    specify do
-      expect(SepaFileParser::Pain001::PaymentInformation).to receive(:new).and_call_original
-    end
+    let(:pain) { SepaFileParser::File.parse 'spec/fixtures/pain001/valid_example.xml' }
+    specify { expect(pain.group_header).to_not be_nil }
+    specify { expect(pain.payment_informations).to_not eq([]) }
+    specify { expect(pain.xml_data).to_not be_nil }
   end
 
-  let(:pain) { SepaFileParser::File.parse 'spec/fixtures/pain001/valid_example.xml' }
-  specify { expect(pain.group_header).to_not be_nil }
-  specify { expect(pain.payment_informations).to_not eq([]) }
-  specify { expect(pain.xml_data).to_not be_nil }
+  context 'version 9' do
+    context 'initialization' do
+      after do
+        SepaFileParser::File.parse 'spec/fixtures/pain001/valid_example_v9.xml'
+      end
+
+      specify { expect(SepaFileParser::GroupHeader).to receive(:new).and_call_original }
+      specify do
+        expect(SepaFileParser::Pain001::PaymentInformation).to receive(:new).and_call_original
+      end
+    end
+
+    let(:pain) { SepaFileParser::File.parse 'spec/fixtures/pain001/valid_example_v9.xml' }
+    specify { expect(pain.group_header).to_not be_nil }
+    specify { expect(pain.payment_informations).to_not eq([]) }
+    specify { expect(pain.xml_data).to_not be_nil }
+  end
 
 end

--- a/spec/lib/sepa_file_parser/pain008/base_spec.rb
+++ b/spec/lib/sepa_file_parser/pain008/base_spec.rb
@@ -4,20 +4,40 @@ require 'spec_helper'
 
 RSpec.describe SepaFileParser::Pain008::Base do
 
-  context 'initialization' do
-    after do
-      SepaFileParser::File.parse 'spec/fixtures/pain008/valid_example.xml'
+  context 'version 2' do
+    context 'initialization' do
+      after do
+        SepaFileParser::File.parse 'spec/fixtures/pain008/valid_example.xml'
+      end
+
+      specify { expect(SepaFileParser::GroupHeader).to receive(:new).and_call_original }
+      specify do
+        expect(SepaFileParser::Pain008::PaymentInformation).to receive(:new).and_call_original
+      end
     end
 
-    specify { expect(SepaFileParser::GroupHeader).to receive(:new).and_call_original }
-    specify do
-      expect(SepaFileParser::Pain008::PaymentInformation).to receive(:new).and_call_original
-    end
+    let(:pain) { SepaFileParser::File.parse 'spec/fixtures/pain008/valid_example.xml' }
+    specify { expect(pain.group_header).to_not be_nil }
+    specify { expect(pain.payment_informations).to_not eq([]) }
+    specify { expect(pain.xml_data).to_not be_nil }
   end
 
-  let(:pain) { SepaFileParser::File.parse 'spec/fixtures/pain008/valid_example.xml' }
-  specify { expect(pain.group_header).to_not be_nil }
-  specify { expect(pain.payment_informations).to_not eq([]) }
-  specify { expect(pain.xml_data).to_not be_nil }
+  context 'version 8' do
+    context 'initialization' do
+      after do
+        SepaFileParser::File.parse 'spec/fixtures/pain008/valid_example_v8.xml'
+      end
+
+      specify { expect(SepaFileParser::GroupHeader).to receive(:new).and_call_original }
+      specify do
+        expect(SepaFileParser::Pain008::PaymentInformation).to receive(:new).and_call_original
+      end
+    end
+
+    let(:pain) { SepaFileParser::File.parse 'spec/fixtures/pain008/valid_example_v8.xml' }
+    specify { expect(pain.group_header).to_not be_nil }
+    specify { expect(pain.payment_informations).to_not eq([]) }
+    specify { expect(pain.xml_data).to_not be_nil }
+  end
 
 end


### PR DESCRIPTION
pain.001.001.09 and pain.008.001.08 are used in more recent EBICS definitions as the go to file format
We should therefore also support them here