### PR TITLE
prevent crash when creditor_identifier is missing

### DIFF
--- a/lib/sepa_file_parser/general/transaction.rb
+++ b/lib/sepa_file_parser/general/transaction.rb
@@ -118,7 +118,7 @@ module SepaFileParser
       @creditor_identifier ||= [
         xml_data.xpath('RltdPties/Cdtr/Id/PrvtId/Othr/Id/text()'),
         xml_data.xpath('RltdPties/Cdtr/Pty/Id/PrvtId/Othr/Id/text()'),
-      ].reject(&:empty?).first.text
+      ].reject(&:empty?).first&.text
     end
 
     def payment_information # May be missing

--- a/spec/fixtures/camt053/missing_creditor_identifier.xml
+++ b/spec/fixtures/camt053/missing_creditor_identifier.xml
@@ -1,0 +1,362 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Document xmlns="urn:iso:std:iso:20022:tech:xsd:camt.053.001.02" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:iso:std:iso:20022:tech:xsd:camt.053.001.02 camt.053.001.02.xsd">
+
+<BkToCstmrStmt>
+  <GrpHdr>
+    <MsgId>053D2013-12-27T22:05:03.0N130000005</MsgId>
+    <CreDtTm>2013-12-27T22:04:52.0+01:00</CreDtTm>
+    <MsgPgntn>
+      <PgNb>1</PgNb>
+      <LastPgInd>true</LastPgInd>
+    </MsgPgntn>
+  </GrpHdr>
+  <Stmt>
+    <Id>0352C5320131227220503</Id>
+    <ElctrncSeqNb>130000005</ElctrncSeqNb>
+    <CreDtTm>2013-12-27T22:04:52.0+01:00</CreDtTm>
+    <Acct>
+      <Id>
+        <IBAN>DE14740618130000033626</IBAN>
+      </Id>
+      <Ccy>EUR</Ccy>
+      <Ownr>
+        <Nm>Testkonto Nummer 1</Nm>
+      </Ownr>
+      <Svcr>
+        <FinInstnId>
+          <BIC>GENODEF1PFK</BIC>
+          <Nm>VR-Bank Rottal-Inn eG</Nm>
+          <Othr>
+            <Id>DE 129267947</Id>
+            <Issr>UmsStId</Issr>
+          </Othr>
+        </FinInstnId>
+      </Svcr>
+    </Acct>
+    <Bal>
+      <Tp>
+        <CdOrPrtry>
+          <Cd>PRCD</Cd>
+        </CdOrPrtry>
+      </Tp>
+      <Amt Ccy="EUR">33.06</Amt>
+      <CdtDbtInd>CRDT</CdtDbtInd>
+      <Dt>
+        <Dt>2013-12-27</Dt>
+      </Dt>
+    </Bal>
+    <Bal>
+      <Tp>
+        <CdOrPrtry>
+          <Cd>CLBD</Cd>
+        </CdOrPrtry>
+      </Tp>
+      <Amt Ccy="EUR">23.06</Amt>
+      <CdtDbtInd>CRDT</CdtDbtInd>
+      <Dt>
+        <Dt>2013-12-27</Dt>
+      </Dt>
+    </Bal>
+    <Ntry>
+      <Amt Ccy="EUR">2.00</Amt>
+      <NtryRef>1234567890sdfghjk</NtryRef>
+      <CdtDbtInd>DBIT</CdtDbtInd>
+      <Sts>BOOK</Sts>
+      <BookgDt>
+        <Dt>2013-12-27</Dt>
+      </BookgDt>
+      <ValDt>
+        <Dt>2013-12-27</Dt>
+      </ValDt>
+      <AcctSvcrRef>2013122710583450000</AcctSvcrRef>
+      <BkTxCd/>
+      <NtryDtls>
+        <TxDtls>
+          <Refs>
+            <AcctSvcrRef>BankReference</AcctSvcrRef>
+            <EndToEndId>EndToEndReference</EndToEndId>
+            <MndtId>MandateReference</MndtId>
+            <PmtInfId>PaymentIdentification</PmtInfId>
+            <TxId>UniqueTransactionId</TxId>
+          </Refs>
+          <AddtlTxInf>AdditionalTransactionInformation</AddtlTxInf>
+          <BkTxCd>
+            <Prtry>
+              <Cd>NTRF+020</Cd>
+              <Issr>ZKA</Issr>
+            </Prtry>
+          </BkTxCd>
+          <RltdPties>
+            <Dbtr>
+              <Nm>Wayne Enterprises</Nm>
+            </Dbtr>
+            <DbtrAcct>
+              <Id>
+                <IBAN>DE24302201900609832118</IBAN>
+              </Id>
+            </DbtrAcct>
+            <Cdtr>
+              <Nm>Testkonto Nummer 2</Nm>
+              <PstlAdr>
+                <AdrLine>Berlin</AdrLine>
+                <AdrLine>Infinite Loop 2</AdrLine>
+                <AdrLine>12345</AdrLine>
+              </PstlAdr>
+            </Cdtr>
+            <CdtrAcct>
+              <Id>
+                <IBAN>DE09300606010012345671</IBAN>
+              </Id>
+              <Tp>
+                <Cd>CACC</Cd>
+              </Tp>
+            </CdtrAcct>
+          </RltdPties>
+          <RltdAgts>
+              <DbtrAgt>
+                <FinInstnId>
+                  <BIC>DAAEDEDDXXX</BIC>
+                  <ClrSysMmbId>
+                    <ClrSysId>
+                      <Cd>ABCDEF</Cd>
+                    </ClrSysId>
+                    <MmbId>1232344234234</MmbId>
+                  </ClrSysMmbId>
+                </FinInstnId>
+              </DbtrAgt>
+              <CdtrAgt>
+                <FinInstnId>
+                  <BIC>DAAEDEDDXXX</BIC>
+                  <ClrSysMmbId>
+                    <ClrSysId>
+                      <Cd>ABCDEF</Cd>
+                    </ClrSysId>
+                    <MmbId>123456789</MmbId>
+                  </ClrSysMmbId>
+                  <Nm>Bank</Nm>
+                  <PstlAdr>
+                    <AdrLine>Infinite Loop 1</AdrLine>
+                    <AdrLine>Berlin</AdrLine>
+                  </PstlAdr>
+                </FinInstnId>
+              </CdtrAgt>
+            </RltdAgts>
+          <RmtInf>
+            <Ustrd>TEST BERWEISUNG MITTELS BLZUND KONTONUMMER - DTA</Ustrd>
+          </RmtInf>
+        </TxDtls>
+      </NtryDtls>
+      <AddtlNtryInf>Überweisungs-Gutschrift; GVC: SEPA Credit Transfer (Einzelbuchung-Haben)</AddtlNtryInf>
+    </Ntry>
+    <Ntry>
+      <Amt Ccy="EUR">3.00</Amt>
+      <CdtDbtInd>DBIT</CdtDbtInd>
+      <Sts>BOOK</Sts>
+      <BookgDt>
+        <Dt>2013-12-27</Dt>
+      </BookgDt>
+      <ValDt>
+        <Dt>2013-12-27</Dt>
+      </ValDt>
+      <AcctSvcrRef>2013122710583600000</AcctSvcrRef>
+      <BkTxCd/>
+      <NtryDtls>
+        <TxDtls>
+          <Refs>
+            <MsgId>CCTI/VRNWSW/b044f24cddb92a502b8a1b5</MsgId>
+            <EndToEndId>NOTPROVIDED</EndToEndId>
+          </Refs>
+          <BkTxCd>
+            <Prtry>
+              <Cd>NMSC+201</Cd>
+              <Issr>ZKA</Issr>
+            </Prtry>
+          </BkTxCd>
+          <RltdPties>
+            <Dbtr>
+              <Nm>Testkonto Nummer 1</Nm>
+            </Dbtr>
+            <DbtrAcct>
+              <Id>
+                <IBAN>DE14740618130000033626</IBAN>
+              </Id>
+            </DbtrAcct>
+            <UltmtDbtr>
+              <Nm>keine Information vorhanden</Nm>
+            </UltmtDbtr>
+            <Cdtr>
+              <Nm>Testkonto Nummer 2</Nm>
+            </Cdtr>
+            <CdtrAcct>
+              <Id>
+                <IBAN>DE58740618130100033626</IBAN>
+              </Id>
+            </CdtrAcct>
+            <UltmtCdtr>
+              <Nm>keine Information vorhanden</Nm>
+            </UltmtCdtr>
+          </RltdPties>
+          <RltdAgts>
+            <CdtrAgt>
+              <FinInstnId>
+                <BIC>GENODEF1PFK</BIC>
+              </FinInstnId>
+            </CdtrAgt>
+          </RltdAgts>
+          <RmtInf>
+            <Ustrd>Test+berweisung mit BIC und IBAN SEPA IBAN: DE58740618130100033626 BIC: GENODEF1PFK</Ustrd>
+          </RmtInf>
+        </TxDtls>
+      </NtryDtls>
+    </Ntry>
+    <Ntry>
+      <Amt Ccy="EUR">1.00</Amt>
+      <CdtDbtInd>CRDT</CdtDbtInd>
+      <Sts>BOOK</Sts>
+      <BookgDt>
+        <Dt>2013-12-27</Dt>
+      </BookgDt>
+      <ValDt>
+        <Dt>2013-12-27</Dt>
+      </ValDt>
+      <AcctSvcrRef>2013122711085260000</AcctSvcrRef>
+      <BkTxCd/>
+      <NtryDtls>
+        <TxDtls>
+          <BkTxCd>
+            <Prtry>
+              <Cd>NMSC+051</Cd>
+              <Issr>ZKA</Issr>
+            </Prtry>
+          </BkTxCd>
+          <RltdPties>
+            <Dbtr>
+              <Nm>Testkonto Nummer 2</Nm>
+            </Dbtr>
+            <DbtrAcct>
+              <Id>
+                <Othr>
+                  <Id>  740618130100033626</Id>
+                  <SchmeNm>
+                    <Cd>BBAN</Cd>
+                  </SchmeNm>
+                </Othr>
+              </Id>
+            </DbtrAcct>
+          </RltdPties>
+          <RmtInf>
+            <Ustrd>R CKBUCHUNG</Ustrd>
+          </RmtInf>
+        </TxDtls>
+      </NtryDtls>
+    </Ntry>
+    <Ntry>
+      <Amt Ccy="EUR">6.00</Amt>
+      <CdtDbtInd>DBIT</CdtDbtInd>
+      <Sts>BOOK</Sts>
+      <BookgDt>
+        <Dt>2013-12-27</Dt>
+      </BookgDt>
+      <ValDt>
+        <Dt>2013-12-27</Dt>
+      </ValDt>
+      <AcctSvcrRef>2013122711513230000</AcctSvcrRef>
+      <BkTxCd/>
+      <NtryDtls>
+        <Btch>
+          <PmtInfId>STZV-PmInf27122013-11:02-2</PmtInfId>
+          <NbOfTxs>2</NbOfTxs>
+        </Btch>
+        <TxDtls>
+          <Refs>
+            <MsgId>STZV-Msg27122013-11:02</MsgId>
+            <EndToEndId>STZV-EtE27122013-11:02-1</EndToEndId>
+          </Refs>
+          <AmtDtls>
+            <TxAmt>
+              <Amt Ccy="EUR">3.50</Amt>
+            </TxAmt>
+          </AmtDtls>
+          <BkTxCd>
+            <Prtry>
+              <Cd>NMSC+201</Cd>
+              <Issr>ZKA</Issr>
+            </Prtry>
+          </BkTxCd>
+          <RltdPties>
+            <Dbtr>
+              <Nm>Testkonto Nummer 2</Nm>
+            </Dbtr>
+            <DbtrAcct>
+              <Id>
+                <IBAN>DE58740618130100033626</IBAN>
+              </Id>
+            </DbtrAcct>
+            <UltmtDbtr>
+              <Nm>keine Information vorhanden</Nm>
+            </UltmtDbtr>
+            <Cdtr>
+              <Nm>Testkonto Nummer 1</Nm>
+            </Cdtr>
+            <CdtrAcct>
+              <Id>
+                <IBAN>DE14740618130000033626</IBAN>
+              </Id>
+            </CdtrAcct>
+            <UltmtCdtr>
+              <Nm>Testkonto</Nm>
+            </UltmtCdtr>
+          </RltdPties>
+          <RmtInf>
+            <Ustrd>Sammelueberwseisung 2. Zahlung   TAN:283044   </Ustrd>
+          </RmtInf>
+        </TxDtls>
+        <TxDtls>
+          <Refs>
+            <MsgId>STZV-Msg27122013-11:02</MsgId>
+            <EndToEndId>STZV-EtE27122013-11:02-2</EndToEndId>
+          </Refs>
+          <AmtDtls>
+            <TxAmt>
+              <Amt Ccy="EUR">2.50</Amt>
+            </TxAmt>
+          </AmtDtls>
+          <BkTxCd>
+            <Prtry>
+              <Cd>NMSC+201</Cd>
+              <Issr>ZKA</Issr>
+            </Prtry>
+          </BkTxCd>
+          <RltdPties>
+            <Dbtr>
+              <Nm>Testkonto Nummer 2</Nm>
+            </Dbtr>
+            <DbtrAcct>
+              <Id>
+                <IBAN>DE58740618130100033626</IBAN>
+              </Id>
+            </DbtrAcct>
+            <UltmtDbtr>
+              <Nm>keine Information vorhanden</Nm>
+            </UltmtDbtr>
+            <Cdtr>
+              <Nm>Testkonto Nummer 1</Nm>
+            </Cdtr>
+            <CdtrAcct>
+              <Id>
+                <IBAN>DE14740618130000033626</IBAN>
+              </Id>
+            </CdtrAcct>
+            <UltmtCdtr>
+              <Nm>Testkonto</Nm>
+            </UltmtCdtr>
+          </RltdPties>
+          <RmtInf>
+            <Ustrd>Sammelueberweisung 1. Zahlung   TAN:283044   </Ustrd>
+          </RmtInf>
+        </TxDtls>
+      </NtryDtls>
+    </Ntry>
+  </Stmt>
+</BkToCstmrStmt>
+</Document>

--- a/spec/lib/sepa_file_parser/general/transaction_spec.rb
+++ b/spec/lib/sepa_file_parser/general/transaction_spec.rb
@@ -136,4 +136,16 @@ RSpec.describe SepaFileParser::Transaction do
     specify { expect(ex_transaction.remittance_information).to eq("INVOICE R77561") }
     end
   end
+
+  context 'missing creditor identifier' do
+    let(:camt)       { SepaFileParser::File.parse('spec/fixtures/camt053/missing_creditor_identifier.xml') }
+    let(:statements) { camt.statements }
+    let(:ex_stmt)    { statements[0] }
+    let(:entries)  { ex_stmt.entries }
+    let(:ex_entry) { entries[0] }
+    let(:transactions)   { ex_entry.transactions }
+    let(:ex_transaction) { transactions[0] }
+
+    specify { expect(ex_transaction.creditor_identifier).to eq(nil) }
+  end
 end


### PR DESCRIPTION
if no creditor_identifier was found the array rejects empty values and returns nil after which a nil.text is being executed which leads to a an exception
```
NoMethodError - undefined method 'text' for nil:
```