### PR TITLE
Fix pain002 group_information_and_status

### DIFF
--- a/lib/sepa_file_parser/pain002/base.rb
+++ b/lib/sepa_file_parser/pain002/base.rb
@@ -15,7 +15,7 @@ module SepaFileParser
         @reports = reports.map { |x| Report.new(x) }
 
         group_information_and_status = xml_data.xpath('CstmrPmtStsRpt/OrgnlGrpInfAndSts')
-        @group_information_and_status = group_information_and_status.map { |x| GroupInformation.new(x) }
+        @group_information_and_status = GroupInformation.new(group_information_and_status)
       end
     end
   end

--- a/spec/lib/sepa_file_parser/pain002/group_information_spec.rb
+++ b/spec/lib/sepa_file_parser/pain002/group_information_spec.rb
@@ -6,12 +6,11 @@ RSpec.describe SepaFileParser::Pain002::GroupInformation do
   SepaFileParser::Xml.register('http://www.six-interbank-clearing.com/de/pain.002.001.03.ch.02.xsd', :pain002)
   let(:pain) { SepaFileParser::File.parse('spec/fixtures/pain002/valid_example_001.03.xml') }
 
-  let(:reports)   { pain.group_information_and_status }
-  let(:ex_report) { pain.group_information_and_status[0] }
+  let(:group_information) { pain.group_information_and_status }
 
-  specify { expect(reports).to all(be_kind_of(described_class)) }
+  specify { expect(group_information).to be_kind_of(described_class) }
 
-  specify { expect(ex_report.status).to eq('ACTC') }
-  specify { expect(ex_report.message_id).to eq('bd381007c00627bb0e5adabd37fbb4') }
+  specify { expect(group_information.status).to eq('ACTC') }
+  specify { expect(group_information.message_id).to eq('bd381007c00627bb0e5adabd37fbb4') }
   specify { expect(pain.xml_data.nil?).to eq(false) }
 end


### PR DESCRIPTION
I'm sorry, but while undoing the last changes, I got something mixed up. The header only exists once, of course, unlike OrgnlPmtInfAndSts