### PR TITLE
Add UETR parsing for transactions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,26 +12,26 @@ GEM
     bigdecimal (3.1.8)
     builder (3.2.4)
     date (3.3.4)
-    diff-lcs (1.5.1)
+    diff-lcs (1.6.2)
     nokogiri (1.19.3-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.19.3-x86_64-linux-gnu)
       racc (~> 1.4)
     racc (1.8.1)
     rake (13.2.1)
-    rspec (3.13.0)
+    rspec (3.13.2)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
       rspec-mocks (~> 3.13.0)
-    rspec-core (3.13.0)
+    rspec-core (3.13.6)
       rspec-support (~> 3.13.0)
-    rspec-expectations (3.13.0)
+    rspec-expectations (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-mocks (3.13.1)
+    rspec-mocks (3.13.8)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-support (3.13.1)
+    rspec-support (3.13.7)
     time (0.3.0)
       date
 
@@ -43,7 +43,7 @@ PLATFORMS
 DEPENDENCIES
   builder (~> 3.2.4)
   rake (~> 13.2.1)
-  rspec (~> 3.13.0)
+  rspec (~> 3.13.2)
   sepa_file_parser!
 
 BUNDLED WITH

--- a/lib/sepa_file_parser/general/transaction.rb
+++ b/lib/sepa_file_parser/general/transaction.rb
@@ -145,6 +145,10 @@ module SepaFileParser
       @reason_code ||= xml_data.xpath('RtrInf/Rsn/Cd/text()').text
     end
 
+    def uetr # May be missing
+      @uetr ||= xml_data.xpath('Refs/UETR/text()').text
+    end
+
     private
 
     def parse_original_currency_amount

--- a/sepa_file_parser.gemspec
+++ b/sepa_file_parser.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_development_dependency 'rake',    '~> 13.2.1'
-  spec.add_development_dependency 'rspec',   '~> 3.13.0'
+  spec.add_development_dependency 'rspec',   '~> 3.13.2'
   spec.add_development_dependency 'builder', '~> 3.2.4'
 
   spec.add_runtime_dependency 'bigdecimal'

--- a/spec/fixtures/camt052/valid_example_v8_2.xml
+++ b/spec/fixtures/camt052/valid_example_v8_2.xml
@@ -102,6 +102,7 @@
 						    <MsgId>pacs009-InstrId-00006</MsgId>
 							<AcctSvcrRef>EK2500858FABA1</AcctSvcrRef>
 							<InstrId>abc123</InstrId>
+							<UETR>b4f8c1a2-7e9d-4b3f-a1c6-d82e4f0a9b5c</UETR>
 						</Refs>
 						<Amt Ccy="EUR">120000.00</Amt>
 						<BkTxCd>

--- a/spec/lib/sepa_file_parser/general/transaction_spec.rb
+++ b/spec/lib/sepa_file_parser/general/transaction_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe SepaFileParser::Transaction do
     specify { expect(ex_transaction.creditor_identifier).to eq(nil) }
   end
 
-  context 'fetch message id from transaction' do
+  context 'camt052' do
     let(:camt)     { SepaFileParser::File.parse('spec/fixtures/camt052/valid_example_v8_2.xml') }
     let(:ex_rpt)   { camt.reports[0] }
     let(:entries)  { ex_rpt.entries }
@@ -175,5 +175,6 @@ RSpec.describe SepaFileParser::Transaction do
     let(:ex_transaction) { transactions[0] }
 
     specify { expect(ex_transaction.message_id).to eq("pacs009-InstrId-00006") }
+    specify { expect(ex_transaction.uetr).to eq("b4f8c1a2-7e9d-4b3f-a1c6-d82e4f0a9b5c") }
   end
 end


### PR DESCRIPTION
Update rspec to 3.13.2
Add UETR parsing for transactions

2.4.2.15.18.2.1.6 UETR <UETR>
Presence: [0..1]
Definition: Universally unique identifier to provide an end-to-end reference of a payment transaction.
Datatype: "UUIDv4Identifier" on page 911