### PR TITLE
BatchDetail total_amount and currency

### DIFF
--- a/lib/sepa_file_parser/general/batch_detail.rb
+++ b/lib/sepa_file_parser/general/batch_detail.rb
@@ -7,6 +7,20 @@ module SepaFileParser
 
     def initialize(xml_data)
       @xml_data = xml_data
+      @amount = xml_data.xpath('TtlAmt/text()').text
+    end
+
+    def total_amount
+      SepaFileParser::Misc.to_amount(@amount)
+    end
+
+    def total_amount_in_cents
+      SepaFileParser::Misc.to_amount_in_cents(@amount)
+    end
+
+    # @return [String]
+    def currency
+      @currency ||= xml_data.xpath('TtlAmt/@Ccy').text
     end
 
     def payment_information_identification
@@ -16,6 +30,7 @@ module SepaFileParser
     def msg_id # may be missing
       @msg_id ||= xml_data.xpath('MsgId/text()').text
     end
+    alias_method :message_id, :msg_id # same like in transaction.rb
 
     def number_of_transactions
       @number_of_transactions ||= xml_data.xpath('NbOfTxs/text()').text

--- a/spec/fixtures/camt052/valid_example_with_batch.xml
+++ b/spec/fixtures/camt052/valid_example_with_batch.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Document xmlns="urn:iso:std:iso:20022:tech:xsd:camt.052.001.02" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <BkToCstmrAcctRpt>
+    <GrpHdr>
+      <MsgId>MSG20260520-001</MsgId>
+      <CreDtTm>2026-05-20T14:56:22Z</CreDtTm>
+    </GrpHdr>
+    <Rpt>
+      <Id>RPT-2026-0042</Id>
+      <CreDtTm>2026-05-20T14:56:22Z</CreDtTm>
+      <Acct>
+        <Id>
+          <Othr>
+            <Id>DE89370400440532013000</Id>
+          </Othr>
+        </Id>
+      </Acct>
+      <Ntry>
+        <Amt Ccy="EUR">1500.00</Amt>
+        <CdtDbtInd>CRDT</CdtDbtInd>
+        <Sts>BOOK</Sts>
+        <BkTxCd>
+          <Domn>
+            <Cd>PMNT</Cd>
+            <Fmly>
+              <Cd>RCDT</Cd>
+              <SubFmlyCd>OEDT</SubFmlyCd>
+            </Fmly>
+          </Domn>
+        </BkTxCd>
+        <NtryDtls>
+          <Btch>
+            <MsgId>SAMMLER-REF-998877</MsgId>
+            <PmtInfId>PMT-INF-001</PmtInfId>
+            <NbOfTxs>3</NbOfTxs>
+            <TtlAmt Ccy="EUR">1500.00</TtlAmt>
+          </Btch>
+        </NtryDtls>
+      </Ntry>
+    </Rpt>
+  </BkToCstmrAcctRpt>
+</Document>

--- a/spec/lib/sepa_file_parser/general/batch_detail_spec.rb
+++ b/spec/lib/sepa_file_parser/general/batch_detail_spec.rb
@@ -3,15 +3,31 @@
 require 'spec_helper'
 
 RSpec.describe SepaFileParser::BatchDetail do
-  let(:camt)       { SepaFileParser::File.parse('spec/fixtures/camt053/valid_example_with_batch.xml') }
-  let(:statements)     { camt.statements }
-  let(:ex_stmt)        { statements[0] }
-  let(:entries)        { ex_stmt.entries }
-  let(:ex_entry)       { entries[0] }
-  let(:batch_detail)   { ex_entry.batch_detail }
+  context 'camt052' do
+    let(:camt)          { SepaFileParser::File.parse('spec/fixtures/camt052/valid_example_with_batch.xml') }
+    let(:reports)       { camt.reports }
+    let(:ex_rpt)        { reports[0] }
+    let(:entries)       { ex_rpt.entries }
+    let(:ex_entry)      { entries[0] }
+    let(:batch_detail)  { ex_entry.batch_detail }
 
-  specify { expect(batch_detail.payment_information_identification).to eq("O0OpeAYTkhjerKu3eE9asw") }
-  specify { expect(batch_detail.number_of_transactions).to eq("3") }
-  specify { expect(batch_detail.msg_id).to eq('02453b1e17c11241073a777ad9c273b4149') }
-  specify { expect(batch_detail.xml_data).to_not be_nil }
+    specify { expect(batch_detail.total_amount).to eq BigDecimal("1500") }
+    specify { expect(batch_detail.total_amount_in_cents).to eq(150000) }
+    specify { expect(batch_detail.currency).to eq("EUR") }
+    specify { expect(batch_detail.xml_data).to_not be_nil }
+  end
+
+  context 'camt053' do
+    let(:camt)       { SepaFileParser::File.parse('spec/fixtures/camt053/valid_example_with_batch.xml') }
+    let(:statements)     { camt.statements }
+    let(:ex_stmt)        { statements[0] }
+    let(:entries)        { ex_stmt.entries }
+    let(:ex_entry)       { entries[0] }
+    let(:batch_detail)   { ex_entry.batch_detail }
+
+    specify { expect(batch_detail.payment_information_identification).to eq("O0OpeAYTkhjerKu3eE9asw") }
+    specify { expect(batch_detail.number_of_transactions).to eq("3") }
+    specify { expect(batch_detail.msg_id).to eq('02453b1e17c11241073a777ad9c273b4149') }
+    specify { expect(batch_detail.xml_data).to_not be_nil }
+  end
 end


### PR DESCRIPTION
6.1.9.3.1.4 TotalAmount <TtlAmt>
Presence: [0..1]
Definition: Total amount of money reported in the batch entry

https://www.iso20022.org/sites/default/files/documents/messages/mdr_part_2/ISO20022_MDRPart2_BankToCustomerCashManagement_2018_2019_v1_0.pdf