### PR TITLE
Add `electronic_sequence_number`

### DIFF
--- a/lib/sepa_file_parser/camt052/report.rb
+++ b/lib/sepa_file_parser/camt052/report.rb
@@ -26,6 +26,10 @@ module SepaFileParser
         @entries ||= xml_data.xpath('Ntry').map{ |x| SepaFileParser::Entry.new(x) }
       end
 
+      def electronic_sequence_number
+        @electronic_sequence_number ||= xml_data.xpath('ElctrncSeqNb/text()').text
+      end
+
       def legal_sequence_number
         @legal_sequence_number ||= xml_data.xpath('LglSeqNb/text()').text
       end

--- a/spec/lib/sepa_file_parser/camt052/report_spec.rb
+++ b/spec/lib/sepa_file_parser/camt052/report_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe SepaFileParser::Camt052::Report do
     let(:ex_rpt)  { camt.reports[0] }
 
     specify { expect(reports).to all(be_kind_of(described_class)) }
+    specify { expect(ex_rpt.electronic_sequence_number).to eq("130000005") }
     specify { expect(ex_rpt.identification).to eq("0352C5220131227110203") }
     specify { expect(ex_rpt.generation_date).to be_kind_of(Time) }
     specify { expect(ex_rpt.account).to be_kind_of(SepaFileParser::Account) }
@@ -16,8 +17,6 @@ RSpec.describe SepaFileParser::Camt052::Report do
 
     specify { expect(ex_rpt.opening_balance).to be_kind_of(SepaFileParser::AccountBalance) }
     specify { expect(ex_rpt.closing_balance).to be_kind_of(SepaFileParser::AccountBalance) }
-
-    specify { expect(ex_rpt.identification).to eq("0352C5220131227110203") }
 
     specify { expect(ex_rpt.from_date_time).to be_nil }
     specify { expect(ex_rpt.to_date_time).to be_nil }


### PR DESCRIPTION
2.4.2.3 ElectronicSequenceNumber <ElctrncSeqNb>
Presence: [0..1]
Definition: Sequential number of the report, as assigned by the account servicer.
Usage: The sequential number is increased incrementally for each report sent electronically.
Datatype: "Number" on page 912